### PR TITLE
wire up ctx with signal interrupt cancellation

### DIFF
--- a/gochain.go
+++ b/gochain.go
@@ -35,27 +35,27 @@ func GetClient(rpcURL string) *RPCClient {
 	return rpc
 }
 
-func (rpc *RPCClient) GetBalance(address string, blockNumber *big.Int) (*big.Int, error) {
-	return rpc.client.BalanceAt(context.Background(), common.HexToAddress(address), blockNumber)
+func (rpc *RPCClient) GetBalance(ctx context.Context, address string, blockNumber *big.Int) (*big.Int, error) {
+	return rpc.client.BalanceAt(ctx, common.HexToAddress(address), blockNumber)
 }
 
-func (rpc *RPCClient) GetCode(address string, blockNumber *big.Int) ([]byte, error) {
-	return rpc.client.CodeAt(context.Background(), common.HexToAddress(address), blockNumber)
+func (rpc *RPCClient) GetCode(ctx context.Context, address string, blockNumber *big.Int) ([]byte, error) {
+	return rpc.client.CodeAt(ctx, common.HexToAddress(address), blockNumber)
 }
 
-func (rpc *RPCClient) GetBlockByNumber(number *big.Int) (*types.Block, error) {
-	return rpc.client.BlockByNumber(context.Background(), number)
+func (rpc *RPCClient) GetBlockByNumber(ctx context.Context, number *big.Int) (*types.Block, error) {
+	return rpc.client.BlockByNumber(ctx, number)
 }
 
-func (rpc *RPCClient) GetTransactionByHash(hash string) (*types.Transaction, bool, error) {
-	return rpc.client.TransactionByHash(context.Background(), common.HexToHash(hash))
+func (rpc *RPCClient) GetTransactionByHash(ctx context.Context, hash string) (*types.Transaction, bool, error) {
+	return rpc.client.TransactionByHash(ctx, common.HexToHash(hash))
 }
 
-func (rpc *RPCClient) GetSnapshot() (*clique.Snapshot, error) {
-	return rpc.client.SnapshotAt(context.Background(), nil)
+func (rpc *RPCClient) GetSnapshot(ctx context.Context) (*clique.Snapshot, error) {
+	return rpc.client.SnapshotAt(ctx, nil)
 }
 
-func (rpc *RPCClient) DeployContract(privateKeyHex string, contractData string) (*types.Transaction, error) {
+func (rpc *RPCClient) DeployContract(ctx context.Context, privateKeyHex string, contractData string) (*types.Transaction, error) {
 	if privateKeyHex[:2] == "0x" {
 		privateKeyHex = privateKeyHex[2:]
 	}
@@ -64,7 +64,7 @@ func (rpc *RPCClient) DeployContract(privateKeyHex string, contractData string) 
 		return nil, errors.New(fmt.Sprintf("Wrong private key:%s", err))
 	}
 
-	gasPrice, err := rpc.client.SuggestGasPrice(context.Background())
+	gasPrice, err := rpc.client.SuggestGasPrice(ctx)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Cannot get gas price:%s", err))
 	}
@@ -76,7 +76,7 @@ func (rpc *RPCClient) DeployContract(privateKeyHex string, contractData string) 
 	}
 
 	fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
-	nonce, err := rpc.client.PendingNonceAt(context.Background(), fromAddress)
+	nonce, err := rpc.client.PendingNonceAt(ctx, fromAddress)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Cannot get nonce:%s", err))
 	}
@@ -87,22 +87,26 @@ func (rpc *RPCClient) DeployContract(privateKeyHex string, contractData string) 
 	tx := types.NewContractCreation(nonce, big.NewInt(0), 2000000, gasPrice, decodedContractData)
 	signedTx, _ := types.SignTx(tx, types.HomesteadSigner{}, privateKey)
 
-	err = rpc.client.SendTransaction(context.Background(), signedTx)
+	err = rpc.client.SendTransaction(ctx, signedTx)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Cannot send transaction:%s", err))
 	}
 
 	return signedTx, nil
 }
-func (rpc *RPCClient) WaitForReceipt(tx *types.Transaction) (*types.Receipt, error) {
+func (rpc *RPCClient) WaitForReceipt(ctx context.Context, tx *types.Transaction) (*types.Receipt, error) {
 	for i := 0; ; i++ {
-		receipt, err := rpc.client.TransactionReceipt(context.Background(), tx.Hash())
+		receipt, err := rpc.client.TransactionReceipt(ctx, tx.Hash())
 		if err == nil {
 			return receipt, nil
 		}
 		if i >= (5) {
 			return nil, errors.New(fmt.Sprintf("Cannot get the receipt:%s", err))
 		}
-		time.Sleep(2 * time.Second)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
 	}
 }

--- a/solc.go
+++ b/solc.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,7 +86,7 @@ func SolidityVersion(source string) (*Solidity, error) {
 }
 
 // CompileSolidityString builds and returns all the contracts contained within a source string.
-func CompileSolidityString(source string) (map[string]*Contract, error) {
+func CompileSolidityString(ctx context.Context, source string) (map[string]*Contract, error) {
 	if len(source) == 0 {
 		return nil, errors.New("solc: empty source string")
 	}
@@ -94,7 +95,7 @@ func CompileSolidityString(source string) (map[string]*Contract, error) {
 		return nil, err
 	}
 	args := append(s.makeArgs(), "--")
-	cmd := exec.Command(s.Path, append(args, "-")...)
+	cmd := exec.CommandContext(ctx, s.Path, append(args, "-")...)
 	cmd.Stdin = strings.NewReader(source)
 	return s.run(cmd, source)
 }


### PR DESCRIPTION
This PR adds interrupt cancellation by wiring around a `context.Context`, allowing users to kill hung commands.
```
web3-cli -network testnet sn
^C2019/01/15 09:50:15 Cannot get snapshot from the network: Post https://testnet-rpc.gochain.io: context canceled
```